### PR TITLE
Fix build issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 lazy_static = "1.4.0"
 notify = { version = "5.1.0", default-features = false, features = ["macos_kqueue"] }
-cedar-agent = "0.1.2"
+cedar-agent = "0.2.0"
 cedar-policy-core = "2.3.0"
 reqwest = { version= "0.11.18", features = ["blocking", "json"] }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -304,8 +304,8 @@ where
 
 fn respond(msg: Result<impl Serialize, Error>) -> impl warp::Reply {
     match msg {
-        Ok(msg) => Ok(warp::reply::json(&msg)),
-        Err(error) => Ok(warp::reply::json(&ErrorMsg { error })),
+        Ok(msg) => warp::reply::json(&msg),
+        Err(error) => warp::reply::json(&ErrorMsg { error }),
     }
 }
 


### PR DESCRIPTION
1. **Cedar-Agent Update**: 
   - Updated the version of `cedar-agent` to "0.2.0". 

2. **Code Changes in `api.rs`**: 
   - Modified the code within the `api.rs` file to resolve type errors that were occurring during the build process.
   - During the initial build process `cargo build`, cedar-agent failed to compile due to a Type error in the tinytodo/src/api.rs code:
   
**Original Code:**
 ```
fn respond(msg: Result<impl Serialize, Error>) -> impl warp::Reply {
    match msg {
        Ok(msg) => Ok(warp::reply::json(&msg)),
        Err(error) => Ok(warp::reply::json(&ErrorMsg { error })),
    }
}
 ```

**Refined Code**:
```
fn respond(msg: Result<impl Serialize, Error>) -> impl warp::Reply {
    match msg {
        Ok(msg) => warp::reply::json(&msg),
        Err(error) => warp::reply::json(&ErrorMsg { error }),
    }
}
```

which removed the `OK(...)` wrapper.
 